### PR TITLE
fix(agents): generate AGENTS.md only at VM startup

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -22,7 +22,6 @@ import { controller as post_users } from './controllers/POST.users'
 import desktop_config from './customization/desktop/config.ts'
 // import { topicize, score } from "./utils/analyze-conversation";
 import { authenticate } from './utils/authenticate-user'
-import { buildAllAgentsFiles } from './utils/copilot-agent'
 import { run_pipeline } from './utils/knowledge/run-pipeline'
 import { setup } from './utils/setup'
 import { cleanupOrphanedVms } from './utils/vm-registry'
@@ -35,7 +34,6 @@ import { cleanupOrphanedVms } from './utils/vm-registry'
 await setup()
 await run_pipeline()
 await cleanupOrphanedVms()
-await buildAllAgentsFiles()
 
 const app = new Hono()
 
@@ -56,8 +54,6 @@ app.use(
 Bun.cron('0 4 * * *', async () => {
   // Update knowledge database with custom content
   await run_pipeline()
-  // Refresh AGENTS.md for all configs (date + schema may have changed)
-  await buildAllAgentsFiles()
   // Score conversation and assign topic with AI
   // await topicize();
   // await score();

--- a/utils/copilot-agent.ts
+++ b/utils/copilot-agent.ts
@@ -14,7 +14,6 @@
 
 import { Database } from 'bun:sqlite'
 import { existsSync } from 'node:fs'
-import { readdir } from 'node:fs/promises'
 import { resolve, join } from 'node:path'
 
 import { today_is } from './today-is'
@@ -86,30 +85,6 @@ async function buildAgentsFile(configId: string): Promise<void> {
 
   await Bun.write(join(knowledgePath, 'AGENTS.md'), parts.join('\n\n'))
   console.log(`[AGENT] AGENTS.md written (${parts.length} sections)`)
-}
-
-/**
- * Builds AGENTS.md for every knowledge directory that exists for the current service.
- * Call at server startup and in the daily cron so Pi always has fresh instructions.
- */
-export async function buildAllAgentsFiles(): Promise<void> {
-  const knowledgeBase = join(PROJECT_ROOT, 'datastores', Bun.env['SERVICE']!, 'knowledge')
-
-  if (!existsSync(knowledgeBase)) {
-    console.log('[AGENT] No knowledge directory found — skipping AGENTS.md build')
-    return
-  }
-
-  const entries = await readdir(knowledgeBase, { withFileTypes: true })
-  const configIds = entries.filter((e) => e.isDirectory()).map((e) => e.name)
-
-  const results = await Promise.allSettled(configIds.map((id) => buildAgentsFile(id)))
-  const ok = results.filter((r) => r.status === 'fulfilled').length
-  results.forEach((r, i) => {
-    if (r.status === 'rejected')
-      console.warn(`[AGENT] Failed to build AGENTS.md for ${configIds[i]}:`, r.reason)
-  })
-  console.log(`[AGENT] Built AGENTS.md for ${ok}/${configIds.length} configs`)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove eager `AGENTS.md` generation from server startup and daily cron in `app.ts`
- remove unused `buildAllAgentsFiles` helper from `utils/copilot-agent.ts`
- keep `AGENTS.md` generation only in the lazy path right before creating a conversation VM

## Why
`AGENTS.md` includes time-sensitive context. Generating it only when a conversation VM is created ensures the date and injected schema are aligned with real runtime usage instead of server boot time.

## Test plan
- [x] `bun test:unit`
- [x] `bun test:e2e`
- [x] `bun lint`
- [x] `bun format`

Made with [Cursor](https://cursor.com)